### PR TITLE
Extra .gitignore lines for Eclipse / Counterclockwise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ target
 *.pdf
 *.log
 *~
+/.classpath
+/.project
+/.settings
+/bin


### PR DESCRIPTION
I added a few extra lines to the .gitignore to make it work cleanly with an Eclipse / Counterclockwise development environment.

Trivial but hopefully useful for some people (myself included....)

CA in the name of Mike Anderson
