### PR TITLE
clojure.core/iterate returns with 'cons', not lazy-seq.

### DIFF
--- a/src/main/clojure/clojure/core/typed/base_env.clj
+++ b/src/main/clojure/clojure/core/typed/base_env.clj
@@ -731,7 +731,7 @@ clojure.core/doall (All [[c :< (U nil (Seqable Any))]]
 clojure.core/dorun (Fn [(U nil (Seqable Any)) -> nil]
                        [AnyInteger (U nil (Seqable Any)) -> nil])
 clojure.core/iterate (All [x]
-                       [[x -> x] x -> (LazySeq x)])
+                       [[x -> x] x -> (ISeq x)])
 clojure.core/memoize (All [x y ...]
                             [[y ... y -> x] -> [y ... y -> x]])
 


### PR DESCRIPTION
``` clojure
user> (clojure-version)
"1.5.1"
user> (class (iterate inc 0))
clojure.lang.Cons
```

I left it `ISeq`, a supertype of ∀`a`.`(U (ASeq a) (LazySeq a))`, as it seems reasonable to some to make it `LazySeq`-returning in the future.
