### PR TITLE
Sort never returns nil

### DIFF
--- a/module-check/src/main/clojure/clojure/core/typed/base_env_common.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/base_env_common.clj
@@ -222,8 +222,8 @@
     clojure.core/distinct? [Any Any * -> Boolean]
     clojure.core/compare [Any Any -> Number]
     clojure.core/sort (All [x]
-                           (IFn [(U nil (Seqable x)) -> (U nil (ASeq x))]
-                                [[x x -> AnyInteger] (U nil (Seqable x)) -> (U nil (ASeq x))]))
+                           (IFn [(Option (Seqable x)) -> (ASeq x)]
+                                [[x x -> AnyInteger] (Option (Seqable x)) -> (ASeq x)]))
     clojure.core/shuffle (All [x]
                               (IFn [(I (Collection x) (Seqable x)) -> (Vec x)]
                                    [(Collection x) -> (Vec x)]))
@@ -294,7 +294,7 @@
     #_clojure.core/chunk-cons
     #_(All [x]
          [(clojure.lang.IChunk x) (Option (Seqable x)) -> (Option (Seqable x))])
-    #_clojure.core/chunk-append 
+    #_clojure.core/chunk-append
     #_(All [x]
                                    [(clojure.lang.ChunkBuffer x) x -> Any])
     #_clojure.core/chunk


### PR DESCRIPTION
The type signature for `sort` seems incorrect, since it never returns `nil`:

```Clojure
functional-kats.core=> (sort nil)
()
functional-kats.core=> (sort [])
()
functional-kats.core=> (sort '())
()
```